### PR TITLE
Improvements and new features for N64 and others.

### DIFF
--- a/DeltaCore/Emulator Core/Video/OpenGLESProcessor.swift
+++ b/DeltaCore/Emulator Core/Video/OpenGLESProcessor.swift
@@ -35,9 +35,7 @@ class OpenGLESProcessor: VideoProcessor
     init(videoFormat: VideoFormat, context: EAGLContext)
     {
         self.videoFormat = videoFormat
-        // TODO figure out why this isn't working
-        // self.context = EAGLContext.createWithBestAvailableAPI(context.sharegroup)
-        self.context = EAGLContext(api: .openGLES2, sharegroup: context.sharegroup)!
+        self.context = EAGLContext(api: .openGLES3, sharegroup: context.sharegroup)!
     }
     
     deinit

--- a/DeltaCore/Emulator Core/Video/VideoManager.swift
+++ b/DeltaCore/Emulator Core/Video/VideoManager.swift
@@ -65,9 +65,7 @@ public class VideoManager: NSObject, VideoRendering
     public init(videoFormat: VideoFormat)
     {
         self.videoFormat = videoFormat
-        // TODO figure out why this isn't working
-        // self.context = EAGLContext.createWithBestAvailableAPI()
-        self.context = EAGLContext(api: .openGLES2)!
+        self.context = EAGLContext(api: .openGLES3)!
         self.ciContext = CIContext(eaglContext: self.context, options: [.workingColorSpace: NSNull()])
         
         switch videoFormat.format

--- a/DeltaCore/UI/Controller/ThumbstickInputView.swift
+++ b/DeltaCore/UI/Controller/ThumbstickInputView.swift
@@ -55,8 +55,8 @@ class ThumbstickInputView: UIView
     private let imageView = UIImageView(image: nil)
     private let panGestureRecognizer = ImmediatePanGestureRecognizer(target: nil, action: nil)
     
-    private let lightFeedbackGenerator = UISelectionFeedbackGenerator()
-    private let mediumFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+    private var lightFeedbackGenerator: UIImpactFeedbackGenerator?
+    private var mediumFeedbackGenerator: UIImpactFeedbackGenerator?
     
     private var isActivated = false
     
@@ -69,6 +69,15 @@ class ThumbstickInputView: UIView
     
     override init(frame: CGRect)
     {
+        
+        if #available(iOS 13.0, *) {
+            self.lightFeedbackGenerator = UIImpactFeedbackGenerator(style: .soft)
+            self.mediumFeedbackGenerator = UIImpactFeedbackGenerator(style: .rigid)
+        } else {
+            self.lightFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+            self.mediumFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
+        }
+        
         super.init(frame: frame)
         
         self.panGestureRecognizer.addTarget(self, action: #selector(ThumbstickInputView.handlePanGesture(_:)))
@@ -106,8 +115,8 @@ private extension ThumbstickInputView
             
             if self.isHapticFeedbackEnabled
             {
-                self.lightFeedbackGenerator.prepare()
-                self.mediumFeedbackGenerator.prepare()
+                self.lightFeedbackGenerator?.prepare()
+                self.mediumFeedbackGenerator?.prepare()
             }
             
             self.update()
@@ -154,7 +163,11 @@ private extension ThumbstickInputView
             
             if self.isHapticFeedbackEnabled
             {
-                self.mediumFeedbackGenerator.impactOccurred()
+                if #available(iOS 13.0, *) {
+                    self.lightFeedbackGenerator?.impactOccurred(intensity: 0.8)
+                } else {
+                    self.lightFeedbackGenerator?.impactOccurred()
+                }
             }
             
             self.update()
@@ -199,7 +212,7 @@ private extension ThumbstickInputView
         var adjustedY = distance * sin(angle)
         adjustedY += center.y
         
-        let insetSideLength = maximumDistance / sqrt(2)
+        let insetSideLength = maximumDistance * 1.5
         let insetFrame = CGRect(x: center.x - insetSideLength / 2,
                                 y: center.y - insetSideLength / 2,
                                 width: insetSideLength,
@@ -232,9 +245,13 @@ private extension ThumbstickInputView
         
         if let direction = Direction(xAxis: xAxis, yAxis: yAxis, threshold: threshold)
         {
-            if self.previousDirection != direction && self.isHapticFeedbackEnabled
+            if self.previousDirection != direction && self.isHapticFeedbackEnabled && magnitude > 0.7
             {
-                self.mediumFeedbackGenerator.impactOccurred()
+                if #available(iOS 13.0, *) {
+                    self.mediumFeedbackGenerator?.impactOccurred(intensity: 0.8)
+                } else {
+                    self.mediumFeedbackGenerator?.impactOccurred()
+                }
             }
             
             self.previousDirection = direction
@@ -243,7 +260,11 @@ private extension ThumbstickInputView
         {
             if isActivated && !self.isActivated && self.isHapticFeedbackEnabled
             {
-                self.lightFeedbackGenerator.selectionChanged()
+                if #available(iOS 13.0, *) {
+                    self.lightFeedbackGenerator?.impactOccurred(intensity: 0.9)
+                } else {
+                    self.lightFeedbackGenerator?.impactOccurred()
+                }
             }
             
             self.previousDirection = nil

--- a/DeltaCore/UI/Game/GameView.swift
+++ b/DeltaCore/UI/Game/GameView.swift
@@ -95,7 +95,7 @@ public class GameView: UIView
             
             // TODO figure out why this isn't working
             // self.glkView.context = EAGLContext.createWithBestAvailableAPI(newValue.sharegroup)
-            self.glkView.context = EAGLContext(api: .openGLES2, sharegroup: newValue.sharegroup)!
+            self.glkView.context = EAGLContext(api: .openGLES3, sharegroup: newValue.sharegroup)!
             self.context = self.makeContext()
             
             DispatchQueue.main.async {
@@ -116,7 +116,7 @@ public class GameView: UIView
     {
         // TODO figure out why this isn't working
         // let eaglContext = EAGLContext.createWithBestAvailableAPI()
-        let eaglContext = EAGLContext(api: .openGLES2)!
+        let eaglContext = EAGLContext(api: .openGLES3)!
         self.glkView = GLKView(frame: CGRect.zero, context: eaglContext)
         
         super.init(frame: frame)
@@ -128,7 +128,7 @@ public class GameView: UIView
     {
         // TODO figure out why this isn't working
         // let eaglContext = EAGLContext.createWithBestAvailableAPI()
-        let eaglContext = EAGLContext(api: .openGLES2)!
+        let eaglContext = EAGLContext(api: .openGLES3)!
         self.glkView = GLKView(frame: CGRect.zero, context: eaglContext)
         
         super.init(coder: aDecoder)

--- a/DeltaCore/UI/Game/GameViewController.swift
+++ b/DeltaCore/UI/Game/GameViewController.swift
@@ -372,7 +372,31 @@ open class GameViewController: UIViewController, GameControllerReceiver
         }
         else
         {
-            self.gameView.frame = gameScreenFrame
+            var screenAspectRatioToUse = screenAspectRatio
+            var availableGameFrameToUse = availableGameFrame
+            
+            // HACK - 4:3 aspect ratio for appropriate consoles
+            // To-do : Add proper cores instead of random resolution check
+            if(screenAspectRatio.height == 240 && screenAspectRatio.width == 256 ||
+               screenAspectRatio.height == 224 && screenAspectRatio.width == 256 ||
+               screenAspectRatio.height == 576 && screenAspectRatio.width == 720)
+            {
+                screenAspectRatioToUse = CGSize(width: screenAspectRatio.width, height: screenAspectRatio.height / (8/7))
+            }
+
+            // N64 should always be linear
+            // Other cores are back to nearest until I make shaders...
+            if(screenAspectRatio.height == 480 && screenAspectRatio.width == 640)
+            {
+                self.gameView.samplerMode = SamplerMode.linear
+            }
+            else
+            {
+                self.gameView.samplerMode = SamplerMode.nearestNeighbor
+            }
+            
+            let gameViewFrame = AVMakeRect(aspectRatio: screenAspectRatioToUse, insideRect: availableGameFrameToUse)
+            self.gameView.frame = gameViewFrame
         }
         
         if self.emulatorCore?.state != .running


### PR DESCRIPTION
- Force GLES 3
Fix for many N64 games rendering wrongly in GLES 2

- Improved haptic feedback for analog stick & behavior improvements
Feels more natural, bounces around and clicks better. Much easier to use on a touch screen.

- **HACK** - Force 4:3 Aspect Ratio
Ideally we want this to be tweakable and optional, and a better way to detect which core to change - It is very needed as it is the real way to play these cores. Games were meant for 4:3, and not how the console actually renders the resolution. 
